### PR TITLE
Add Flutter radio streaming app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# radioagakiza
+# Radio Agakiza
+
+This repository contains a minimal Flutter application for streaming the Radio Agakiza online station. The app uses [`just_audio`](https://pub.dev/packages/just_audio) and [`just_audio_background`](https://pub.dev/packages/just_audio_background) to provide background playback with simple play, pause and stop controls.
+
+## Features
+- Streams audio from `https://cast6.asurahosting.com/proxy/radioaga/stream`.
+- Play, pause and stop controls.
+- Continues playing in the background while using other apps or when the screen is off.
+- Basic error handling and a display of the current playback status.
+
+## Running
+1. Ensure you have Flutter installed.
+2. Run `flutter pub get` to fetch dependencies.
+3. Use `flutter run` to launch the application on your device or emulator.
+
+The `AndroidManifest.xml` already includes the necessary permissions for internet access and foreground service usage.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.radioagakiza">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application
+        android:label="RadioAgakiza"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name="com.example.radioagakiza.MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:just_audio_background/just_audio_background.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await JustAudioBackground.init(
+    androidNotificationChannelId: 'com.example.radioagakiza.channel.audio',
+    androidNotificationChannelName: 'Radio Playback',
+    androidNotificationOngoing: true,
+  );
+  runApp(const RadioApp());
+}
+
+class RadioApp extends StatelessWidget {
+  const RadioApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Radio Agakiza',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const RadioHomePage(),
+    );
+  }
+}
+
+class RadioHomePage extends StatefulWidget {
+  const RadioHomePage({Key? key}) : super(key: key);
+
+  @override
+  State<RadioHomePage> createState() => _RadioHomePageState();
+}
+
+class _RadioHomePageState extends State<RadioHomePage> {
+  final AudioPlayer _player = AudioPlayer();
+  final String _streamUrl = 'https://cast6.asurahosting.com/proxy/radioaga/stream';
+  String _status = 'Stopped';
+
+  Future<void> _play() async {
+    try {
+      await _player.setUrl(_streamUrl);
+      await _player.play();
+      setState(() => _status = 'Playing');
+    } catch (e) {
+      setState(() => _status = 'Error: unable to play');
+    }
+  }
+
+  Future<void> _pause() async {
+    try {
+      await _player.pause();
+      setState(() => _status = 'Paused');
+    } catch (_) {}
+  }
+
+  Future<void> _stop() async {
+    try {
+      await _player.stop();
+      setState(() => _status = 'Stopped');
+    } catch (_) {}
+  }
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Radio Agakiza')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Status: \$_status'),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ElevatedButton(onPressed: _play, child: const Text('Play')),
+                const SizedBox(width: 10),
+                ElevatedButton(onPressed: _pause, child: const Text('Pause')),
+                const SizedBox(width: 10),
+                ElevatedButton(onPressed: _stop, child: const Text('Stop')),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,21 @@
+name: radioagakiza
+description: Online radio streaming app
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  just_audio: ^0.9.36
+  just_audio_background: ^0.0.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create Flutter app skeleton with audio streaming
- add play/pause/stop controls and background playback
- document running instructions

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853eb0c3e448324aef0d4f84e64ee1d